### PR TITLE
[Feat] Core Data Manager, 데이터 모델, Info.plist, AppDelegate 수정

### DIFF
--- a/nbc-kickboard/nbc-kickboard/App/AppDelegate.swift
+++ b/nbc-kickboard/nbc-kickboard/App/AppDelegate.swift
@@ -47,6 +47,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         let url = URL(fileURLWithPath: path)
+        let characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
         
         do {
             let jsonData = try Data(contentsOf: url)
@@ -58,7 +59,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 entity.longitude = location.longitude
                 entity.batteryStatus = Int16.random(in: 20...100)
                 entity.isRented = false
-                entity.kickboardCode = UUID().uuidString
+                entity.kickboardCode = String((0..<8).map { _ in
+                    characters.randomElement()!
+                })
             }
             
             try context.save()

--- a/nbc-kickboard/nbc-kickboard/App/AppDelegate.swift
+++ b/nbc-kickboard/nbc-kickboard/App/AppDelegate.swift
@@ -10,72 +10,62 @@ import CoreData
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        setupInitialKickboardData()
         return true
     }
-
+    
     // MARK: UISceneSession Lifecycle
-
+    
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
+    
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-    // MARK: - Core Data stack
-
-    lazy var persistentContainer: NSPersistentContainer = {
-        /*
-         The persistent container for the application. This implementation
-         creates and returns a container, having loaded the store for the
-         application to it. This property is optional since there are legitimate
-         error conditions that could cause the creation of the store to fail.
-        */
-        let container = NSPersistentContainer(name: "nbc_kickboard")
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-            if let error = error as NSError? {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                 
-                /*
-                 Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was.
-                 */
-                fatalError("Unresolved error \(error), \(error.userInfo)")
+    
+    
+    // MARK: - 킥보드 초기 데이터 동기화 구문
+    func setupInitialKickboardData() {
+        let context = CoreDataManager.shared.context
+        let fetchRequest: NSFetchRequest<KickboardEntity> = KickboardEntity.fetchRequest()
+        
+        do {
+            let count = try context.count(for: fetchRequest)
+            if count == 0 {
+                loadInitialData(context: context)
             }
-        })
-        return container
-    }()
-
-    // MARK: - Core Data Saving support
-
-    func saveContext () {
-        let context = persistentContainer.viewContext
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nserror = error as NSError
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
+        } catch {
+            print("Failed to fetch kickboard count: \(error)")
         }
     }
-
+    
+    private func loadInitialData(context: NSManagedObjectContext) {
+        guard let path = Bundle.main.path(forResource: "latitude_longitude", ofType: "json") else {
+            print("Failed to load latitude_longitude.json")
+            return
+        }
+        
+        let url = URL(fileURLWithPath: path)
+        
+        do {
+            let jsonData = try Data(contentsOf: url)
+            let locations = try JSONDecoder().decode([Location].self, from: jsonData)
+            
+            for location in locations {
+                let entity = KickboardEntity(context: context)
+                entity.latitude = location.latitude
+                entity.longitude = location.longitude
+                entity.batteryStatus = Int16.random(in: 20...100)
+                entity.isRented = false
+                entity.kickboardCode = UUID().uuidString
+            }
+            
+            try context.save()
+        } catch {
+            print("Failed to seed initial data: \(error)")
+        }
+    }
+    
 }
 

--- a/nbc-kickboard/nbc-kickboard/App/Info.plist
+++ b/nbc-kickboard/nbc-kickboard/App/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>We need your location to show nearby places and directions</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/nbc-kickboard/nbc-kickboard/App/SceneDelegate.swift
+++ b/nbc-kickboard/nbc-kickboard/App/SceneDelegate.swift
@@ -54,11 +54,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
-
-        // Save changes in the application's managed object context when the application transitions to the background.
-        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
-
-
 }
 

--- a/nbc-kickboard/nbc-kickboard/App/nbc_kickboard.xcdatamodeld/nbc_kickboard.xcdatamodel/contents
+++ b/nbc-kickboard/nbc-kickboard/App/nbc_kickboard.xcdatamodeld/nbc_kickboard.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24B91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24A348" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="HistoryEntity" representedClassName="HistoryEntity" syncable="YES">
         <attribute name="cost" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="rentDate" attributeType="Date" usesScalarValueType="NO"/>
@@ -13,8 +13,8 @@
         <attribute name="kickboardCode" attributeType="String"/>
         <attribute name="latitude" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="longitude" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <relationship name="histories" toMany="YES" deletionRule="Cascade" destinationEntity="HistoryEntity" inverseName="kickboard" inverseEntity="HistoryEntity"/>
-        <relationship name="kickboardType" maxCount="1" deletionRule="Nullify" destinationEntity="KickboardTypeEntity" inverseName="kickboards" inverseEntity="KickboardTypeEntity"/>
+        <relationship name="histories" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="HistoryEntity" inverseName="kickboard" inverseEntity="HistoryEntity"/>
+        <relationship name="kickboardType" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="KickboardTypeEntity" inverseName="kickboards" inverseEntity="KickboardTypeEntity"/>
     </entity>
     <entity name="KickboardTypeEntity" representedClassName="KickboardTypeEntity" syncable="YES">
         <attribute name="typeName" attributeType="String"/>

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/CoreDataManager.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/CoreDataManager.swift
@@ -10,18 +10,19 @@ import CoreData
 class CoreDataManager {
     static let shared = CoreDataManager()
     
-    lazy var persistentContainer: NSPersistentContainer = {
-        let container = NSPersistentContainer(name: "nbc_kickboard")
-        container.loadPersistentStores { description, error in
+    let persistentContainer: NSPersistentContainer
+    
+    var context: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+    
+    private init() {
+        persistentContainer = NSPersistentContainer(name: "nbc_kickboard")
+        persistentContainer.loadPersistentStores { _, error in
             if let error = error {
                 fatalError("Unable to load persistent stores: \(error)")
             }
         }
-        return container
-    }()
-    
-    var context: NSManagedObjectContext {
-        return persistentContainer.viewContext
     }
     
     func saveContext() {

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/CoreDataManager.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/CoreDataManager.swift
@@ -1,0 +1,36 @@
+//
+//  CoreDataManager.swift
+//  nbc-kickboard
+//
+//  Created by Neoself on 12/17/24.
+//
+import Foundation
+import CoreData
+
+class CoreDataManager {
+    static let shared = CoreDataManager()
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "nbc_kickboard")
+        container.loadPersistentStores { description, error in
+            if let error = error {
+                fatalError("Unable to load persistent stores: \(error)")
+            }
+        }
+        return container
+    }()
+    
+    var context: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+    
+    func saveContext() {
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                print("Error saving context: \(error)")
+            }
+        }
+    }
+}

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/Kickboard.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/Kickboard.swift
@@ -8,5 +8,14 @@
 import Foundation
 
 struct Kickboard {
-    
+    let longitude: Double
+    let latitude: Double
+    let kickboardCode: String
+    let isRented: Bool
+    let batteryStatus: Int16
+}
+
+struct Location: Codable {
+    let latitude: Double
+    let longitude: Double
 }


### PR DESCRIPTION
## 📓 Overview
-  데이터 초기화 간 에러 해결위해 CoreData optional 임시 추가
- Info.plist 내부 위치권한 요청 내용 추가
- Kickboard, Location 데이터 모델 추가
- AppDelegate 내부 CoreData 관련 로직 제거 및 킥보드 데이터 초기화 구문 추가

## 🤔 고민 내용
- KickboardEntity의 Relative에 KickboardType이 non-optional로 연결되어있는데, 현재 KickboardType이 구체화되어있지 않아, 데이터 초기화 간에 이를 구현시켜 연결할 수가 없었습니다. 이에, 현재 임시로 KickboardType를 optional로 변경해주었으니, 참고 부탁드립니다.
- 서울 쪽은 위도.경도 정보가 json파일에 없어서인지 마커가 안뜨더라고요...?? 좀더 알아보고 구두로 전달드리겠습니다.

## 📸 Screenshot
CoreData에 킥보드 관련 객체들 집어넣은 후에, MapKit에 마커로 표시하는 것 구현했고, 드래그로 지도 위치 변경될때, 마커위치랑 보여야 하는 킥보드 객체들 갱신되는 것까지 구현이 된 상황입니다.

![스크린샷 2024-12-17 오전 11 40 34](https://github.com/user-attachments/assets/fe4e4e27-59c9-4f8e-a998-26635b77e1ee)
