### PR TITLE
회원가입 로직 구현 + UseCase 패턴을 적용

### DIFF
--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Errors/ValidationError.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Errors/ValidationError.swift
@@ -1,0 +1,11 @@
+//
+//  ValidationError.swift
+//  nbc-kickboard
+//
+//  Created by 임성수 on 12/18/24.
+//
+
+/// 문자열 validation 중 Alert에서 사용자에게 검증이 통과되지 못한 이유를 알려주기 위한 커스텀 에러
+struct ValidationError: Error {
+    let messages: [String]
+}

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UIButton+Extensions.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UIButton+Extensions.swift
@@ -61,7 +61,7 @@ extension UIButton {
         config.buttonSize = .medium
         config.titleAlignment = .center
         config.baseBackgroundColor = isFilled ? Colors.mint : Colors.white
-        config.baseForegroundColor = isFilled ? Colors.bg : Colors.label
+        config.baseForegroundColor = isFilled ? Colors.background : Colors.label
         config.background.cornerRadius = 8
         
         if isFilled == false {
@@ -72,7 +72,7 @@ extension UIButton {
         self.configurationUpdateHandler = { btn in
             switch self.state {
             case .highlighted:
-                config.baseForegroundColor = isFilled ? Colors.bg.withAlphaComponent(0.8) : Colors.white.withAlphaComponent(0.8)
+                config.baseForegroundColor = isFilled ? Colors.background.withAlphaComponent(0.8) : Colors.white.withAlphaComponent(0.8)
             default:
                 config.baseBackgroundColor = isFilled ? Colors.mint : Colors.white
             }

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UIButton+Extensions.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UIButton+Extensions.swift
@@ -2,7 +2,6 @@
 //  UIButton+Extensions.swift
 //  nbc-kickboard
 //
-//  Created by MaxBook on 12/17/24.
 //
 
 import UIKit

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UIFont+extensions.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UIFont+extensions.swift
@@ -2,7 +2,6 @@
 //  UIFont+extensions.swift
 //  nbc-kickboard
 //
-//  Created by MaxBook on 12/16/24.
 //
 
 import UIKit
@@ -25,8 +24,6 @@ extension UIFont {
             weightString = "Medium"
         }
 
-        print("font information")
-        print("\(familyName) \(weightString)")
         return UIFont(name: "\(familyName) \(weightString)", size: fontSize) ?? .systemFont(ofSize: fontSize, weight: .bold)
     }
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UILabel+extension.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UILabel+extension.swift
@@ -2,7 +2,6 @@
 //  UILabel+extension.swift
 //  nbc-kickboard
 //
-//  Created by MaxBook on 12/17/24.
 //
 
 import UIKit
@@ -11,7 +10,8 @@ import SnapKit
 
 extension UILabel {
     /// 각 화면 상단 좌측에 들어가는 헤드라인 텍스트용 라벨
-    func applyHeadlineStyle() {
+    func applyHeadlineStyle(text: String) {
+        self.text = text
         self.font = Fonts.headline
         self.textColor = Colors.label
         self.textAlignment = .left

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UIScrollView+extensions.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UIScrollView+extensions.swift
@@ -2,7 +2,6 @@
 //  UIScrollView+extensions.swift
 //  nbc-kickboard
 //
-//  Created by MaxBook on 12/17/24.
 //
 
 import UIKit

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UITextField+extensions.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UITextField+extensions.swift
@@ -2,7 +2,6 @@
 //  UITextField+extensions.swift
 //  nbc-kickboard
 //
-//  Created by MaxBook on 12/17/24.
 //
 
 import UIKit

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UIView+extensions.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UIView+extensions.swift
@@ -2,7 +2,6 @@
 //  UIView+extensions.swift
 //  nbc-kickboard
 //
-//  Created by MaxBook on 12/17/24.
 //
 
 import UIKit

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/PasswordManager.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/PasswordManager.swift
@@ -8,23 +8,21 @@
 import Foundation
 import CryptoKit
 
-protocol PasswordManageable {
-    func encryptPassword(_ password: String) throws -> String
-}
 
-struct PasswordManager: PasswordManageable {
-    func encryptPassword(_ password: String) throws -> String {
+struct PasswordManager {
+    static func encryptPassword(_ password: String) throws -> String {
         guard let data = password.data(using: .utf8) else {
             throw AppError.PasswordManagerError.encryptionFailed
         }
-        return hash(data: data)
-    }
-    
-    private func hash(data: Data) -> String {
-        let digest = SHA256.hash(data: data)
-        let hashString = digest
-            .compactMap { String(format: "%02x", $0) }
-            .joined()
-        return hashString
+        
+        let result = {
+            let digest = SHA256.hash(data: data)
+            let hashString = digest
+                .compactMap { String(format: "%02x", $0) }
+                .joined()
+            return hashString
+        }
+        
+        return result()
     }
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/ThemeManager/Colors.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/ThemeManager/Colors.swift
@@ -12,7 +12,7 @@ struct Colors {
     // 라이트에서 화이트, 다크에서 블랙
     static let label: UIColor = UIColor.label
     // 라이트에서 블랙, 다크에서 화이트
-    static let bg: UIColor = UIColor.systemBackground
+    static let background: UIColor = UIColor.systemBackground
     // 라이트에서 밝은 회색, 다크에서 어두운 회색
     static let fill: UIColor = UIColor.systemFill
     

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/ThemeManager/Layouts.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/ThemeManager/Layouts.swift
@@ -1,5 +1,5 @@
 //
-//  Numbers.swift
+//  Layouts.swift
 //
 //
 

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/AuthViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/AuthViewController.swift
@@ -43,7 +43,6 @@ class AuthViewController: UIViewController, LoginViewDelegate {
     override func viewWillDisappear(_ animated: Bool) {
         navigationController?.isNavigationBarHidden = false
     }
-    
 }
 
 
@@ -51,7 +50,7 @@ class AuthViewController: UIViewController, LoginViewDelegate {
 
 extension AuthViewController {
     private func setupUI() {
-        view.backgroundColor = Colors.bg
+        view.backgroundColor = Colors.background
     }
 }
 
@@ -73,8 +72,6 @@ extension AuthViewController {
     func getAuthentication() {
         let username = loginView.inputUsername.text
         let password = loginView.inputPassword.text
-        
-        
     }
 }
 

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/AuthViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/AuthViewController.swift
@@ -2,31 +2,27 @@
 //  AuthViewController.swift
 //  nbc-kickboard
 //
-//  Created by MaxBook on 12/13/24.
 //
 
 import UIKit
 import SnapKit
 
 
-enum AuthViewSelector {
-    case login
-    case signup
-}
 
-class AuthViewController: UIViewController {
+
+class AuthViewController: UIViewController, LoginViewDelegate {
     // MARK: - Properties
     
-    let loginView = LoginView()
-    let signupView = SignupView()
-    
-    let currentView: AuthViewSelector
+    private let loginView = LoginView()
+    private let userRepository: UserEntityRepositoryProtocol
     
     // MARK: - init & Life cycles
     
-    init() {
-        self.currentView = .login
+    init(userRepository: UserEntityRepositoryProtocol = UserEntityRepository()) {
+        self.userRepository = userRepository
         super.init(nibName: nil, bundle: nil)
+        
+        loginView.delegate = self
     }
     
     required init?(coder: NSCoder) {
@@ -43,6 +39,11 @@ class AuthViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         navigationController?.setNavigationBarHidden(true, animated: true)
     }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        navigationController?.isNavigationBarHidden = false
+    }
+    
 }
 
 
@@ -50,7 +51,7 @@ class AuthViewController: UIViewController {
 
 extension AuthViewController {
     private func setupUI() {
-        view.backgroundColor = Colors.white
+        view.backgroundColor = Colors.bg
     }
 }
 
@@ -61,6 +62,24 @@ extension AuthViewController {
     
 }
 
+
+// MARK: - Action Management & Mapping
+
+extension AuthViewController {
+    func navigateToSignup() {
+        navigationController?.pushViewController(SignupViewController(), animated: true)
+    }
+    
+    func getAuthentication() {
+        let username = loginView.inputUsername.text
+        let password = loginView.inputPassword.text
+        
+        
+    }
+}
+
+
+// MARK: - Preview
 
 @available(iOS 17.0, *)
 #Preview {

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Components/AgreementToggleView.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Components/AgreementToggleView.swift
@@ -1,0 +1,14 @@
+//
+//  AgreementToggleView.swift
+//  nbc-kickboard
+//
+//  Created by MaxBook on 12/18/24.
+//
+
+import UIKit
+import SnapKit
+
+final class AgreementToggleView: UIView {
+    
+    
+}

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Components/LoginView.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Components/LoginView.swift
@@ -2,15 +2,16 @@
 //  LoginView.swift
 //  nbc-kickboard
 //
-//  Created by MaxBook on 12/16/24.
 //
 
 import UIKit
 import SnapKit
 
 
+/// LoginView 와 AuthViewController를 연결하는 delegate
 protocol LoginViewDelegate: AnyObject {
-    
+    func navigateToSignup()
+    func getAuthentication()
 }
 
 final class LoginView: UIView {
@@ -29,7 +30,7 @@ final class LoginView: UIView {
     let lastView = UIView() // 스크롤뷰를 작동하게 만들어주는 마지막 빈 레이아웃
     
     weak var delegate: LoginViewDelegate?
-        
+   
     
     // MARK: - init & Life cycles
     
@@ -37,11 +38,13 @@ final class LoginView: UIView {
         super.init(frame: .zero)
         
         setupUI()
+        mapActionToButtons()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
 }
 
 
@@ -67,16 +70,12 @@ extension LoginView {
         // MARK: - Components Styling & Configuration
         
         scrollView.applyVerticalStyle()
-        
-        inputUsername.applyInputBoxStyle(placeholder: "Please enter your ID")
-        inputPassword.applyInputBoxStyle(placeholder: "Please enter your PW")
-        
         inputLabelUsername.applyInputLabelStyle(text: "ID")
+        inputUsername.applyInputBoxStyle(placeholder: "Please enter your ID")
         inputLabelPassword.applyInputLabelStyle(text: "PW")
-        
+        inputPassword.applyInputBoxStyle(placeholder: "Please enter your PW")
         loginButton.applyFullSizeButtonStyle(title: "로그인", bgColor: Colors.main)
         signupButton.applyFullSizeButtonStyle(title: "회원가입", bgColor: Colors.blue)
-        
         
         contentView.backgroundColor = Colors.white
         coverImageView.image = UIImage(named: "coverImage")
@@ -95,7 +94,7 @@ extension LoginView {
         }
         
         inputLabelUsername.snp.makeConstraints {
-            $0.top.equalTo(coverImageView.snp.bottom).offset(56)
+            $0.top.equalTo(coverImageView.snp.bottom).offset(54)
             $0.leading.trailing.equalToSuperview().inset(Layouts.padding)
         }
         
@@ -128,7 +127,7 @@ extension LoginView {
             $0.top.equalTo(signupButton.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview().inset(Layouts.padding)
             $0.height.equalTo(10)
-            $0.bottom.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(10)
         }
         
         contentView.snp.makeConstraints {
@@ -139,6 +138,19 @@ extension LoginView {
 }
 
 
+// MARK: - Action Management & Mapping
+
 extension LoginView {
+    func mapActionToButtons() {
+        signupButton.applyButtonAction(action: tapSignupButton)
+        loginButton.applyButtonAction(action: tapLoginButton)
+    }
     
+    func tapSignupButton() {
+        delegate?.navigateToSignup()
+    }
+    
+    func tapLoginButton() {
+        delegate?.getAuthentication()
+    }
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Components/SignupView.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Components/SignupView.swift
@@ -2,22 +2,33 @@
 //  SignupView.swift
 //  nbc-kickboard
 //
-//  Created by MaxBook on 12/17/24.
 //
 
 import UIKit
 import SnapKit
 
+
+/// SignupView 와 SignupViewController를 연결하는 delegate
+protocol SignupViewDelegate: AnyObject {
+    func requestSignup(username: String, password: String)
+}
+
+
 final class SignupView: UIView {
     // MARK: - Properties
     
-    let coverImageView = UIImageView()
+    let scrollView = UIScrollView() // 스크롤 기능 추가
+    let contentView = UIView() // 실제 컨텐츠를 담는 공간
+    
+    let headerLabel = UILabel()
     let inputUsername = UITextField()
     let inputPassword = UITextField()
-    let loginButton = UIButton()
+    let inputLabelUsername = UILabel()
+    let inputLabelPassword = UILabel()
     let signupButton = UIButton()
+    let lastView = UIView()
     
-    weak var delegate: LoginViewDelegate?
+    weak var delegate: SignupViewDelegate?
     
     
     // MARK: - init & Life cycles
@@ -25,6 +36,7 @@ final class SignupView: UIView {
     init() {
         super.init(frame: .zero)
         setupUI()
+        mapActionToButtons()
     }
     
     required init?(coder: NSCoder) {
@@ -37,6 +49,96 @@ final class SignupView: UIView {
 
 extension SignupView {
     func setupUI() {
+        [
+            headerLabel,
+            inputUsername,
+            inputPassword,
+            inputLabelUsername,
+            inputLabelPassword,
+            signupButton,
+            lastView
+        ].forEach { contentView.addSubview($0) }
         
+        scrollView.addSubview(contentView)
+        self.addSubview(scrollView)
+        
+        
+        // MARK: - Components Styling & Configuration
+
+        scrollView.applyVerticalStyle()
+        headerLabel.applyHeadlineStyle(text: "회원 가입")
+        
+        inputUsername.applyInputBoxStyle(placeholder: "Please enter your ID")
+        inputPassword.applyInputBoxStyle(placeholder: "Please enter your PW")
+        
+        inputLabelUsername.applyInputLabelStyle(text: "ID")
+        inputLabelPassword.applyInputLabelStyle(text: "PW")
+        
+        signupButton.applyFullSizeButtonStyle(title: "회원가입", bgColor: Colors.main)
+        
+        
+        // MARK: - Layouts
+
+        scrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        headerLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(Layouts.padding)
+        }
+        
+        inputLabelUsername.snp.makeConstraints {
+            $0.top.equalTo(headerLabel.snp.bottom).offset(40)
+            $0.leading.trailing.equalToSuperview().inset(Layouts.padding)
+        }
+        
+        inputUsername.snp.makeConstraints {
+            $0.top.equalTo(inputLabelUsername.snp.bottom).offset(8)
+            $0.leading.trailing.equalToSuperview().inset(Layouts.padding)
+        }
+        
+        inputLabelPassword.snp.makeConstraints {
+            $0.top.equalTo(inputUsername.snp.bottom).offset(24)
+            $0.leading.trailing.equalToSuperview().inset(Layouts.padding)
+        }
+        
+        inputPassword.snp.makeConstraints {
+            $0.top.equalTo(inputLabelPassword.snp.bottom).offset(8)
+            $0.leading.trailing.equalToSuperview().inset(Layouts.padding)
+        }
+        
+        signupButton.snp.makeConstraints {
+            $0.top.equalTo(inputPassword.snp.bottom).offset(100)
+            $0.leading.trailing.equalToSuperview().inset(Layouts.padding)
+        }
+        
+        lastView.snp.makeConstraints {
+            $0.top.equalTo(signupButton.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(Layouts.padding)
+            $0.height.equalTo(10)
+            $0.bottom.equalToSuperview().inset(20)
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalTo(scrollView.snp.width)
+        }
+    }
+}
+
+
+// MARK: - Action Management & Mapping
+
+extension SignupView {
+    func mapActionToButtons() {
+        signupButton.applyButtonAction(action: tapSignupButton)
+    }
+    
+    func tapSignupButton() {
+        if let username: String = inputUsername.text,
+           let password: String = inputPassword.text  {
+            delegate?.requestSignup(username: username, password: password)
+        }
     }
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Repositories/AuthRepository.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Repositories/AuthRepository.swift
@@ -1,0 +1,6 @@
+//
+//  AuthRepository.swift
+//  nbc-kickboard
+//
+//
+

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Repositories/UserEntityRepository.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Repositories/UserEntityRepository.swift
@@ -2,17 +2,16 @@
 //  UserRepository.swift
 //  nbc-kickboard
 //
-//  Created by MaxBook on 12/17/24.
 //
 
 import Foundation
 import CoreData
 
 protocol UserEntityRepositoryProtocol {
-    func createUser(username: String, password: String, isAdmin: Bool) -> UserEntity?
+    func createUser(username: String, hashedPw: String, isAdmin: Bool) -> UserEntity?
     func fetchUser(by username: String) -> UserEntity?
     func fetchAllUsers() -> [UserEntity]
-    func updatePassword(user: UserEntity, oldPassword: String, newPassword: String)
+    func updatePassword(user: UserEntity, hashedPw: String)
     func deleteUser(user: UserEntity)
     func softDeleteUser(user: UserEntity)
 }
@@ -20,6 +19,7 @@ protocol UserEntityRepositoryProtocol {
 
 final class UserEntityRepository: UserEntityRepositoryProtocol {
     private let context: NSManagedObjectContext
+    
     
     init(context: NSManagedObjectContext = CoreDataManager.shared.context) {
         self.context = context
@@ -43,31 +43,19 @@ final class UserEntityRepository: UserEntityRepositoryProtocol {
     ///   - password: 문자열로 받아 이를 해쉬화암호로 변경하고 저장
     ///   - isAdmin: 관리자 아이디인지 여부 결정.
     /// - Returns: 새로운 사용자 생성 후 해당 사용자 객체를 리턴.
-    func createUser(username: String, password: String, isAdmin: Bool) -> UserEntity? {
+    func createUser(username: String, hashedPw: String, isAdmin: Bool) -> UserEntity? {
         let newUser = UserEntity(context: context)
         
-        // 1. name 유효성 검사
-        
-        
-        // 2. name 중복검사
-        
-        
-        // 3. 패스워드 유효성 검사
-        
-        
-        // 4. 암호 해쉬화
-        let hashedPassword: String = ""
-        
-        // 5. 저장하기
         newUser.username = username
         newUser.isAdmin = isAdmin
-        newUser.password = hashedPassword
+        newUser.password = hashedPw
         
+        // 5. 저장하기
         print("before: \(newUser)")
         saveContext()
         print("after: \(newUser)")
         
-        // 6. 이름으로 검색해서 정보 가져오기 : 제대로 저장되었는지 판단하고 암호 제외하기 위함.
+        // 6. 이름으로 검색해서 정보 가져오기 : 제대로 저장되었는지 판단하고 암호 제외한 값을 반한.
         let fetchedUser = fetchUser(by: username)
         
         return fetchedUser
@@ -91,6 +79,7 @@ final class UserEntityRepository: UserEntityRepositoryProtocol {
         }
     }
     
+    
     /// 서비스의 모든 이용자 가져오기
     /// - Returns: 모든 이용자의 이름과 관리자 여부 데이터 가져오기.
     func fetchAllUsers() -> [UserEntity] {
@@ -111,15 +100,15 @@ final class UserEntityRepository: UserEntityRepositoryProtocol {
     ///   - user: 변경하고자 하는 사용자 데이터
     ///   - oldPassword: 기존에 사용 중이던 암호
     ///   - newPassword: 새로운 암호
-    func updatePassword(user: UserEntity, oldPassword: String, newPassword: String) {
+    func updatePassword(user: UserEntity, hashedPw: String) {
         // 1. 기존 패스워드 일치하는지 검사 (기존 암호 해쉬화 후 coredata에 저장된 데이터와 비교)
+        
         
         // 2. 신규 패스워드 유효성 검사
         
+        
         // 3. 신규 패스워드 해쉬화
-        let hashedPassword: String = ""
-
-        user.setValue( hashedPassword, forKey: "password")
+        user.password = hashedPw
         saveContext()
     }
     
@@ -137,12 +126,3 @@ final class UserEntityRepository: UserEntityRepositoryProtocol {
     }
 }
 
-
-
-/*
- Question
- 
- 1. 프로토콜을 적용했을 경우 각 메소드에 대한 주석은 어디에 작성하는 게 좋을까?
- 2. CoreDataStack의 saveContext() 메소드에 관하여.
- 
- */

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/SignupViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/SignupViewController.swift
@@ -1,0 +1,68 @@
+//
+//  SignupViewController.swift
+//  nbc-kickboard
+//
+//
+
+import UIKit
+import SnapKit
+
+
+class SignupViewController: UIViewController, SignupViewDelegate {
+    // MARK: - Properties
+    
+    let userEntityRepository: UserEntityRepository
+    let signupUseCase: SignupUseCase
+    
+    let signupView = SignupView()
+    
+    // MARK: - init & Life cycles
+    
+    init() {
+        self.userEntityRepository = UserEntityRepository()
+        self.signupUseCase = SignupUseCase(userEntityRepository: userEntityRepository)
+        super.init(nibName: nil, bundle: nil)
+        
+        signupView.delegate = self
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view = signupView
+        setupUI()
+    }    
+}
+
+
+// MARK: - Setup UI Layouts
+
+extension SignupViewController {
+    private func setupUI() {
+        view.backgroundColor = Colors.bg
+    }
+}
+
+
+// MARK: - Navigation Controll
+
+extension SignupViewController {
+    
+}
+
+
+// MARK: - Action Management & Mapping
+
+extension SignupViewController {
+    
+    func requestSignup(username: String, password: String) {
+        
+    }
+
+}
+    
+

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/SignupViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/SignupViewController.swift
@@ -43,7 +43,7 @@ class SignupViewController: UIViewController, SignupViewDelegate {
 
 extension SignupViewController {
     private func setupUI() {
-        view.backgroundColor = Colors.bg
+        view.backgroundColor = Colors.background
     }
 }
 
@@ -60,7 +60,7 @@ extension SignupViewController {
 extension SignupViewController {
     
     func requestSignup(username: String, password: String) {
-        
+//        signupUseCase.execute()
     }
 
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/UseCases/LoginUseCase.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/UseCases/LoginUseCase.swift
@@ -1,0 +1,7 @@
+//
+//  LoginUseCase.swift
+//  nbc-kickboard
+//
+//  Created by MaxBook on 12/18/24.
+//
+

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/UseCases/SignupUseCase.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/UseCases/SignupUseCase.swift
@@ -7,17 +7,30 @@
 
 import Foundation
 
+
+/// 새로운 사용자 등록 UseCase
+///
+/// - execute(_:) : 사용자 등록을 실행하는 메서드
 struct SignupUseCase: UseCaseProtocol {
     typealias Input = (username: String, password: String, isAdmin: Bool)
-    typealias Output = Result<UserEntity, Error>
+    typealias Output = Result<Void, Error>
     
-    private let passwordManager: PasswordManageable = PasswordManager()
     private let userEntityRepository: UserEntityRepositoryProtocol
     
     init(userEntityRepository: UserEntityRepositoryProtocol) {
         self.userEntityRepository = userEntityRepository
     }
     
+    /// 새로운 사용자 데이터를 받아 검증 후 UserEntity에 저장.
+    ///
+    /// - Parameters:
+    ///   - input: 사용자 입력 정보 (`Input` 타입)으로, 아래의 세 가지 정보를 포함합니다:
+    ///     - **username** (`String`): 사용자가 입력한 이름으로 고유 아이디로 사용됩니다.
+    ///     - **password** (`String`): 사용자가 입력한 비밀번호입니다.
+    ///     - **isAdmin** (`Bool`): 관리자 권한 여부를 나타냅니다. 기본값은 `false`입니다.
+    /// - Returns:
+    ///   성공적으로 사용자 생성이 완료되면 `Void`를 반환합니다.
+    ///   실패한 경우, `ValidationError`를 포함한 에러가 반환됩니다.
     func execute(_ input: Input) -> Output {
         var errors: [String] = [] // alert에서 띄워줄 가입 실패 원인 전달용.
         let (username, password, isAdmin) = input
@@ -56,7 +69,7 @@ struct SignupUseCase: UseCaseProtocol {
         
         // 4. 암호 해쉬화
         do {
-            let hashedPw: String = try passwordManager.encryptPassword(password)
+            let hashedPw: String = try PasswordManager.encryptPassword(password)
         } catch {
             print("패스워드 암호화 및 저장에 실패하였습니다. \(error)")
         }
@@ -67,6 +80,6 @@ struct SignupUseCase: UseCaseProtocol {
             return .failure(ValidationError(messages: errors))
         }
         
-        return .success(newUser)
+        return .success(())
     }
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/UseCases/SignupUseCase.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/UseCases/SignupUseCase.swift
@@ -1,0 +1,72 @@
+//
+//  SignupUseCase.swift
+//  nbc-kickboard
+//
+//  Created by MaxBook on 12/18/24.
+//
+
+import Foundation
+
+struct SignupUseCase: UseCaseProtocol {
+    typealias Input = (username: String, password: String, isAdmin: Bool)
+    typealias Output = Result<UserEntity, Error>
+    
+    private let passwordManager: PasswordManageable = PasswordManager()
+    private let userEntityRepository: UserEntityRepositoryProtocol
+    
+    init(userEntityRepository: UserEntityRepositoryProtocol) {
+        self.userEntityRepository = userEntityRepository
+    }
+    
+    func execute(_ input: Input) -> Output {
+        var errors: [String] = [] // alert에서 띄워줄 가입 실패 원인 전달용.
+        let (username, password, isAdmin) = input
+        
+        // 1. name 유효성 검사
+        var usernameValidation = UsernameValidator.validate(username)
+        switch usernameValidation {
+        case .success:
+            print("사용자 이름 유효성 검사 성공")
+        case .failure(let error):
+            print("사용자 이름 유효성 검사 실패: \(error)")
+            
+            errors.append(contentsOf: error.messages)
+            return .failure(error)
+        }
+        
+        // 2. name 중복검사
+        if let _ = userEntityRepository.fetchUser(by: username) {
+            print("사용자 이름 중복 검사 실패")
+            
+            errors.append("해당 사용자 이름은 사용할 수 없습니다.")
+            return .failure(ValidationError(messages: errors))
+        }
+        
+        // 3. 패스워드 유효성 검사
+        var passwordValidation = UserPasswordValidator.validate(password)
+        switch passwordValidation {
+        case .success:
+            print("사용자 암호 유효성 검사 성공")
+        case .failure(let error):
+            print("사용자 암호 유효성 검사 실패: \(error)")
+            
+            errors.append(contentsOf: error.messages)
+            return .failure(error)
+        }
+        
+        // 4. 암호 해쉬화
+        do {
+            let hashedPw: String = try passwordManager.encryptPassword(password)
+        } catch {
+            print("패스워드 암호화 및 저장에 실패하였습니다. \(error)")
+        }
+        
+        // 5. 사용자 생성
+        guard let newUser: UserEntity = userEntityRepository.createUser(username: username, hashedPw: password, isAdmin: isAdmin) else {
+            errors.append("사용자 생성에 실패하였습니다.")
+            return .failure(ValidationError(messages: errors))
+        }
+        
+        return .success(newUser)
+    }
+}

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/UseCases/UpdateUserPwUseCase.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/UseCases/UpdateUserPwUseCase.swift
@@ -1,0 +1,33 @@
+//
+//  UpdateUserPwUseCase.swift
+//  nbc-kickboard
+//
+//  Created by MaxBook on 12/18/24.
+//
+
+import Foundation
+
+//struct UpdateUserPwUseCase: UseCaseProtocol {
+//    typealias Input = (username: String, password: String)
+//    typealias Output = Result<UserEntity, Error>
+//    
+//    private let passwordManager: PasswordManageable = PasswordManager()
+//    private let userEntityRepository: UserEntityRepositoryProtocol
+//    
+//    init(userEntityRepository: UserEntityRepositoryProtocol) {
+//        self.userEntityRepository = userEntityRepository
+//    }
+//    
+//    func execute(_ input: Input) -> Output {
+//        // 1. 기존 패스워드 일치하는지 검사 (기존 암호 해쉬화 후 coredata에 저장된 데이터와 비교)
+//
+//
+//        // 2. 신규 패스워드 유효성 검사
+//
+//
+//        // 3. 신규 패스워드 해쉬화
+//    }
+//}
+
+
+

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/UseCases/UseCaseProtocol.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/UseCases/UseCaseProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  UseCaseProtocol.swift
+//  nbc-kickboard
+//
+//
+
+import Foundation
+
+protocol UseCaseProtocol {
+    associatedtype Input
+    associatedtype Output
+    
+    func execute(_ input: Input) -> Output
+}

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Validators/UserPasswordValidator.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Validators/UserPasswordValidator.swift
@@ -1,0 +1,59 @@
+//
+//  ValidatePasswordUseCase.swift
+//  nbc-kickboard
+//
+//
+
+import Foundation
+
+protocol UserPasswordValidatorProtocol {
+    static func validate(_ password: String) -> Result<Void, ValidationError>
+}
+
+struct UserPasswordValidator: UserPasswordValidatorProtocol {
+    /// 비밀번호의 유효성을 검사합니다.
+    /// - Parameter password: 사용자가 입력한 비밀번호
+    /// - Returns: 각 단계별 유효성 검사에 실패한 경우의 그 원인을 수집하여 반환. 최종적으로 사용자에게 Alert로 띄워주기.
+    ///            errors.isEmpty 로 유효성 검사 판단.
+    static func validate(_ password: String) -> Result<Void, ValidationError> {
+        var errors: [String] = []
+        
+        // 1. 허용된 문자(영문 대문자, 소문자, 숫자, 일부 특수기호( ! @ # $ % ^ & * _ ) )만 사용 가능.
+        if !NSPredicate(format: "SELF MATCHES %@", "^[A-Za-z0-9!@#$%^&*_]+$").evaluate(with: password) {
+            errors.append("비밀번호는 영문 대소문자, 숫자 및 다음의 특수기호만 사용 가능합니다. ! @ # $ % ^ & * _ ")
+        }
+        
+        // 2. 영어 대문자, 소문자, 숫자, 특수문자 최소 1개씩 포함되어야 한다.
+        if !NSPredicate(format: "SELF MATCHES %@", ".*[A-Z].*").evaluate(with: password) {
+            errors.append("비밀번호에는 최소 하나의 대문자가 포함되어야 합니다.")
+        }
+        
+        if !NSPredicate(format: "SELF MATCHES %@", ".*[a-z].*").evaluate(with: password) {
+            errors.append("비밀번호에는 최소 하나의 소문자가 포함되어야 합니다.")
+        }
+        
+        if !NSPredicate(format: "SELF MATCHES %@", ".*[0-9].*").evaluate(with: password) {
+            errors.append("비밀번호에는 최소 하나의 숫자가 포함되어야 합니다.")
+        }
+        
+        if !NSPredicate(format: "SELF MATCHES %@", ".*[!@#$%^&*_].*").evaluate(with: password) {
+            errors.append("비밀번호에는 최소 하나의 특수문자(! @ # $ % ^ & * _)가 포함되어야 합니다.")
+        }
+        
+        // 3. 공백 금지
+        if password.contains(" ") {
+            errors.append("비밀번호에는 공백을 포함할 수 없습니다.")
+        }
+        
+        // 4. 길이 제한 8 - 20
+        if password.count < 8 || password.count > 20 {
+            errors.append("비밀번호는 8자 이상 20자 이하여야 합니다.")
+        }
+        
+        if errors.isEmpty {
+            return .success(())
+        } else {
+            return .failure(ValidationError(messages: errors))
+        }
+    }
+}

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Validators/UsernameValidator.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Validators/UsernameValidator.swift
@@ -1,0 +1,47 @@
+//
+//  ValidateUsernameUseCase.swift
+//  nbc-kickboard
+//
+//
+
+import Foundation
+
+protocol UsernameValidatorProtocol {
+    static func validate(_ username: String) -> Result<Void, ValidationError>
+}
+
+struct UsernameValidator: UsernameValidatorProtocol {
+    /// 아이디의 유효성을 검사합니다.
+    /// - Parameter username: 사용자가 입력한 아이디
+    /// - Returns: 각 단계별 유효성 검사에 실패한 경우의 그 원인을 수집하여 반환. 최종적으로 사용자에게 Alert로 띄워주기.
+    ///            errors.isEmpty 로 유효성 검사 판단.
+    static func validate(_ username: String) -> Result<Void, ValidationError> {
+        var errors: [String] = []
+        
+        // 1. 허용된 문자만 사용
+        if !NSPredicate(format: "SELF MATCHES %@", "^[A-Za-z0-9_-]+$").evaluate(with: username) {
+            errors.append("아이디는 영문 대소문자, 숫자, 언더바(_), 하이픈(-)만 사용할 수 있습니다.")
+        }
+        
+        // 2. 공백 금지
+        if username.contains(" ") {
+            errors.append("아이디에는 공백을 포함할 수 없습니다.")
+        }
+        
+        // 3. 길이 제한 4 - 20
+        if username.count < 4 || username.count > 20 {
+            errors.append("아이디는 4자 이상 20자 이하여야 합니다.")
+        }
+        
+        // 4. 숫자만으로 이루어진 아이디 금지
+        if NSPredicate(format: "SELF MATCHES %@", "^[0-9]+$").evaluate(with: username) {
+            errors.append("아이디는 숫자만으로 구성될 수 없습니다.")
+        }
+        
+        if errors.isEmpty {
+            return .success(())
+        } else {
+            return .failure(ValidationError(messages: errors))
+        }
+    }
+}

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/SearchView/SearchViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/SearchView/SearchViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 import SnapKit
-
+import SwiftUI
 
 class SearchViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate {
     
@@ -15,7 +15,7 @@ class SearchViewController: UIViewController, UITableViewDataSource, UITableView
         view.backgroundColor = .white
         
         // .env 파일에서 API 키 로드
-        
+        kakaoApiKey = "7823c3c3a09136e2ad5f13d733813ae8"
         
         // Search Bar 설정
         searchBar.delegate = self

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/SearchView/SearchViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/SearchView/SearchViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 import SnapKit
-import SwiftUI
+
 
 class SearchViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate {
     
@@ -15,7 +15,7 @@ class SearchViewController: UIViewController, UITableViewDataSource, UITableView
         view.backgroundColor = .white
         
         // .env 파일에서 API 키 로드
-        kakaoApiKey = "7823c3c3a09136e2ad5f13d733813ae8"
+        
         
         // Search Bar 설정
         searchBar.delegate = self


### PR DESCRIPTION
## 📓 Overview
- 사용자 가입 단계에서 사용자 이름 및 암호 검증 단계 적용
- UseCase를 통해 Repository 를 관리하는 코드 추가
- UseCase의 반환 타입을 모두 Result 타입으로 지정하여, 뷰 측에서 이를 이용할 수 있도록 함.

## 🤔 고민 내용
- Repository를 활용하는 방안에 대해 고민하다가 클린 아키텍쳐까지 공부하며 힘든 새벽시간을 보냈습니다.
- 어느정도 이해를 했다고 생각하는 수준까지의 정말 심플한 형태로 UseCase 활용을 도입해 보았습니다.
- 동시에 추후 UseCase를 활용한 트랜잭션 관리까지 고민할 수 있었습니다.