### PR TITLE
코어데이터 스택 구현

### DIFF
--- a/nbc-kickboard/nbc-kickboard/App/nbc_kickboard.xcdatamodeld/nbc_kickboard.xcdatamodel/contents
+++ b/nbc-kickboard/nbc-kickboard/App/nbc_kickboard.xcdatamodeld/nbc_kickboard.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24A348" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24B91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="HistoryEntity" representedClassName="HistoryEntity" syncable="YES">
         <attribute name="cost" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="rentDate" attributeType="Date" usesScalarValueType="NO"/>
@@ -24,6 +24,6 @@
         <attribute name="isAdmin" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="password" attributeType="String"/>
         <attribute name="username" attributeType="String"/>
-        <relationship name="histories" toMany="YES" deletionRule="Cascade" destinationEntity="HistoryEntity" inverseName="user" inverseEntity="HistoryEntity"/>
+        <relationship name="histories" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="HistoryEntity" inverseName="user" inverseEntity="HistoryEntity"/>
     </entity>
 </model>

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Errors/AppError.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Errors/AppError.swift
@@ -18,4 +18,18 @@ enum AppError: Error {
             }
         }
     }
+    
+    enum CoreDataStackError: LocalizedError {
+        case dataTransformationFailed
+        case noMatchingItem
+        
+        var errorDescription: String? {
+            switch self {
+            case .dataTransformationFailed:
+                return "엔티티 -> 모델 변환 실패"
+            case .noMatchingItem:
+                return "일치하는 아이템 없음"
+            }
+        }
+    }
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/CoreDataStack.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/CoreDataStack.swift
@@ -1,0 +1,414 @@
+//
+//  CoreDataStack.swift
+//  nbc-kickboard
+//
+//  Created by 권승용 on 12/18/24.
+//
+
+import Foundation
+import CoreData
+
+final class CoreDataStack {
+    static let shared = CoreDataStack()
+    
+    var persistentContainer: NSPersistentContainer
+    
+    private init() {
+        let container = NSPersistentContainer(name: "nbc_kickboard")
+        
+        container.loadPersistentStores { _, error in
+            if let error {
+                fatalError("Failed to load persistent stores: \(error.localizedDescription)")
+            }
+        }
+        
+        persistentContainer = container
+    }
+    
+    private func save() {
+        guard persistentContainer.viewContext.hasChanges else { return }
+        
+        do {
+            try persistentContainer.viewContext.save()
+        } catch {
+            print("Failed to save the context:", error.localizedDescription)
+        }
+    }
+    
+    func deleteAll() throws {
+        try deleteAllUsers()
+        try deleteAllKickboards()
+        try deleteAllKickboardType()
+        try deleteAllHistory()
+    }
+}
+
+// MARK: - UserEntity CRUD
+
+extension CoreDataStack {
+    func createUser(name: String, password: String, isAdmin: Bool) {
+        guard let entity = NSEntityDescription.entity(forEntityName: "UserEntity", in: persistentContainer.viewContext) else {
+            return
+        }
+        
+        let newUser = NSManagedObject(entity: entity, insertInto: self.persistentContainer.viewContext)
+        newUser.setValue(name, forKey: UserEntity.Key.username)
+        newUser.setValue(password, forKey: UserEntity.Key.password)
+        newUser.setValue(isAdmin, forKey: UserEntity.Key.isAdmin)
+        // 새로운 유저 생성 시 빈 history 생성
+        newUser.setValue(Set<HistoryEntity>(), forKey: UserEntity.Key.histories)
+        save()
+    }
+    
+    func readAllUsers() throws -> [User] {
+        var result: [User] = []
+        let fetchRequest = UserEntity.fetchRequest()
+        
+        let userEntities = try persistentContainer.viewContext.fetch(fetchRequest)
+        for userEntity in userEntities as [NSManagedObject] {
+            if let username = userEntity.value(forKey: UserEntity.Key.username) as? String,
+               let isAdmin = userEntity.value(forKey: UserEntity.Key.isAdmin) as? Bool {
+                let newUser = User(username: username, isAdmin: isAdmin)
+                result.append(newUser)
+            }
+        }
+        return result
+    }
+    
+    func readUser(name: String) throws -> User {
+        let fetchRequest = UserEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "username == %@", name)
+        
+        guard let userEntity = try persistentContainer.viewContext.fetch(fetchRequest).first else {
+            throw AppError.CoreDataStackError.noMatchingItem
+        }
+        if let username = userEntity.value(forKey: UserEntity.Key.username) as? String,
+           let isAdmin = userEntity.value(forKey: UserEntity.Key.isAdmin) as? Bool {
+            let newUser = User(username: username, isAdmin: isAdmin)
+            return newUser
+        } else {
+            throw AppError.CoreDataStackError.dataTransformationFailed
+        }
+    }
+    
+    func updateUser(name: String, password: String, isAdmin: Bool) throws {
+        let fetchRequest = UserEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "username == %@", name)
+        
+        if let result = try persistentContainer.viewContext.fetch(fetchRequest).first {
+            result.setValue(password, forKey: UserEntity.Key.password)
+            result.setValue(isAdmin, forKey: UserEntity.Key.isAdmin)
+            save()
+        }
+    }
+    
+    func deleteUser(name: String) throws {
+        let request = UserEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "username == %@", name)
+        
+        if let result = try self.persistentContainer.viewContext.fetch(request).first {
+            persistentContainer.viewContext.delete(result)
+            save()
+        }
+    }
+    
+    func deleteAllUsers() throws {
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "UserEntity")
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+        
+        try persistentContainer.viewContext.execute(deleteRequest)
+        save()
+    }
+}
+
+// MARK: - Kickboard Entity CRUD
+
+extension CoreDataStack {
+    func createKickboard(
+        kickboardCode: String,
+        batteryStatus: Int16,
+        isRented: Bool,
+        latitude: Double,
+        longitude: Double,
+        type: KickboardType
+    ) throws {
+        guard let entity = NSEntityDescription.entity(forEntityName: "KickboardEntity", in: persistentContainer.viewContext) else {
+            return
+        }
+        
+        let newKickboard = NSManagedObject(entity: entity, insertInto: self.persistentContainer.viewContext)
+        newKickboard.setValue(kickboardCode, forKey: KickboardEntity.Key.kickboardCode)
+        newKickboard.setValue(batteryStatus, forKey: KickboardEntity.Key.batteryStatus)
+        newKickboard.setValue(isRented, forKey: KickboardEntity.Key.isRented)
+        newKickboard.setValue(latitude, forKey: KickboardEntity.Key.latitude)
+        newKickboard.setValue(longitude, forKey: KickboardEntity.Key.longitude)
+        newKickboard.setValue(Set<HistoryEntity>(), forKey: KickboardEntity.Key.histories)
+        
+        let kickboardTypeEntity = try findKickboardTypeEntity(with: type.rawValue)
+        newKickboard.setValue(kickboardTypeEntity, forKey: KickboardEntity.Key.kickboardType)
+        save()
+    }
+    
+    func readKickboard(kickboardCode: String) throws -> Kickboard {
+        let fetchRequest = KickboardEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "kickboardCode == %@", kickboardCode)
+        
+        guard let kickboardEntity = try self.persistentContainer.viewContext.fetch(fetchRequest).first else {
+            throw AppError.CoreDataStackError.noMatchingItem
+        }
+        if let batteryStatus = kickboardEntity.value(forKey: KickboardEntity.Key.batteryStatus) as? Int16,
+           let isRented = kickboardEntity.value(forKey: KickboardEntity.Key.isRented) as? Bool,
+           let latitude = kickboardEntity.value(forKey: KickboardEntity.Key.latitude) as? Double,
+           let longitude = kickboardEntity.value(forKey: KickboardEntity.Key.longitude) as? Double,
+           let kickboardTypeEntity = kickboardEntity.value(forKey: KickboardEntity.Key.kickboardType) as? KickboardTypeEntity,
+           let typeName = kickboardTypeEntity.value(forKey: KickboardTypeEntity.Key.typeName) as? String {
+            return Kickboard(
+                longitude: longitude,
+                latitude: latitude,
+                kickboardCode: kickboardCode,
+                isRented: isRented,
+                batteryStatus: batteryStatus,
+                type: KickboardType(rawValue: typeName) ?? .basic
+            )
+        } else {
+            throw AppError.CoreDataStackError.dataTransformationFailed
+        }
+    }
+    
+    func updateKickboard(
+        kickboardCode: String,
+        batteryStatus: Int16,
+        isRented: Bool,
+        latitude: Double,
+        longitude: Double,
+        type: KickboardType
+    ) throws {
+        let fetchRequest = KickboardEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "kickboardCode == %@", kickboardCode)
+        
+        if let result = try self.persistentContainer.viewContext.fetch(fetchRequest).first {
+            result.setValue(batteryStatus, forKey: KickboardEntity.Key.batteryStatus)
+            result.setValue(isRented, forKey: KickboardEntity.Key.isRented)
+            result.setValue(latitude, forKey: KickboardEntity.Key.latitude)
+            result.setValue(longitude, forKey: KickboardEntity.Key.longitude)
+            let kickboardTypeEntity = try findKickboardTypeEntity(with: type.rawValue)
+            result.setValue(kickboardTypeEntity, forKey: KickboardEntity.Key.kickboardType)
+            save()
+        }
+    }
+    
+    func deleteKickboard(kickboardCode: String) throws {
+        let fetchRequest = KickboardEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "kickboardCode == %@", kickboardCode)
+        
+        guard let result = try self.persistentContainer.viewContext.fetch(fetchRequest).first else {
+            throw AppError.CoreDataStackError.noMatchingItem
+        }
+        persistentContainer.viewContext.delete(result)
+        save()
+    }
+    
+    func deleteAllKickboards() throws {
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "KickboardEntity")
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+        
+        try persistentContainer.viewContext.execute(deleteRequest)
+        save()
+    }
+}
+
+// MARK: - KickboardType CRUD
+
+extension CoreDataStack {
+    func createKickboardType(name: String) {
+        guard let entity = NSEntityDescription.entity(forEntityName: "KickboardTypeEntity", in: persistentContainer.viewContext) else {
+            return
+        }
+        
+        let newType = NSManagedObject(entity: entity, insertInto: self.persistentContainer.viewContext)
+        newType.setValue(name, forKey: KickboardTypeEntity.Key.typeName)
+        newType.setValue(Set<KickboardEntity>(), forKey: KickboardTypeEntity.Key.kickboards)
+        
+        save()
+    }
+    
+    func deleteAllKickboardType() throws {
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "KickboardTypeEntity")
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+        
+        try persistentContainer.viewContext.execute(deleteRequest)
+        save()
+    }
+}
+
+// MARK: - History CRUD
+
+extension CoreDataStack {
+    func createHistory(
+        username: String,
+        kickboardCode: String,
+        cost: Int16,
+        rentDate: Date,
+        totalRentTime: Int16
+    ) throws {
+        guard let entity = NSEntityDescription.entity(forEntityName: "HistoryEntity", in: persistentContainer.viewContext) else {
+            return
+        }
+        
+        guard let userEntity = try findUserEntity(with: username) else {
+            throw AppError.CoreDataStackError.noMatchingItem
+        }
+        
+        guard let kickboardEntity = try findKickboardEntity(with: kickboardCode) else {
+            throw AppError.CoreDataStackError.noMatchingItem
+        }
+        
+        // many to one
+        let newHistory = NSManagedObject(entity: entity, insertInto: self.persistentContainer.viewContext)
+        newHistory.setValue(cost, forKey: HistoryEntity.Key.cost)
+        newHistory.setValue(rentDate, forKey: HistoryEntity.Key.rentDate)
+        newHistory.setValue(totalRentTime, forKey: HistoryEntity.Key.totalRentTime)
+        newHistory.setValue(userEntity, forKey: HistoryEntity.Key.user)
+        newHistory.setValue(kickboardEntity, forKey: HistoryEntity.Key.kickboard)
+        
+        // Update the relationships
+        if var userHistories = userEntity.value(forKey: UserEntity.Key.histories) as? Set<HistoryEntity> {
+            userHistories.insert(newHistory as! HistoryEntity)
+            userEntity.setValue(userHistories, forKey: UserEntity.Key.histories)
+        }
+        
+        if var kickboardHistories = kickboardEntity.value(forKey: KickboardEntity.Key.histories) as? Set<HistoryEntity> {
+            kickboardHistories.insert(newHistory as! HistoryEntity)
+            kickboardEntity.setValue(kickboardHistories, forKey: KickboardEntity.Key.histories)
+        }
+        
+        save()
+    }
+    
+    func readAllHistory(of username: String) throws -> [History] {
+        var result: [History] = []
+        let fetchRequest = HistoryEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "user.username == %@", username)
+        
+        let historyEntities = try persistentContainer.viewContext.fetch(fetchRequest)
+        for historyEntity in historyEntities {
+            if let cost = historyEntity.value(forKey: HistoryEntity.Key.cost) as? Int16,
+               let rentDate = historyEntity.value(forKey: HistoryEntity.Key.rentDate) as? Date,
+               let totalRentTime = historyEntity.value(forKey: HistoryEntity.Key.totalRentTime) as? Int16,
+               
+                let kickboardEntity = historyEntity.value(forKey: HistoryEntity.Key.kickboard) as? KickboardEntity,
+               let kickboardCode = kickboardEntity.value(forKey: KickboardEntity.Key.kickboardCode) as? String,
+               let batteryStatus = kickboardEntity.value(forKey: KickboardEntity.Key.batteryStatus) as? Int16,
+               let isRented = kickboardEntity.value(forKey: KickboardEntity.Key.isRented) as? Bool,
+               let latitude = kickboardEntity.value(forKey: KickboardEntity.Key.latitude) as? Double,
+               let longitude = kickboardEntity.value(forKey: KickboardEntity.Key.longitude) as? Double,
+               
+                let kickboardTypeEntity = kickboardEntity.value(forKey: KickboardEntity.Key.kickboardType) as? KickboardTypeEntity,
+               let typeName = kickboardTypeEntity.value(forKey: KickboardTypeEntity.Key.typeName) as? String,
+               
+                let userEntity = historyEntity.value(forKey: HistoryEntity.Key.user) as? UserEntity,
+               let username = userEntity.value(forKey: UserEntity.Key.username) as? String,
+               let isAdmin = userEntity.value(forKey: UserEntity.Key.isAdmin) as? Bool {
+                
+                let history = History(
+                    cost: cost,
+                    rentDate: rentDate,
+                    totalRentTime: totalRentTime,
+                    kickboard: Kickboard(
+                        longitude: longitude,
+                        latitude: latitude,
+                        kickboardCode: kickboardCode,
+                        isRented: isRented,
+                        batteryStatus: batteryStatus,
+                        type: KickboardType(rawValue: typeName) ?? .basic
+                    ),
+                    user: User(
+                        username: username,
+                        isAdmin: isAdmin
+                    )
+                )
+                result.append(history)
+            }
+        }
+        return result
+    }
+    
+    func deleteAllHistory() throws {
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "HistoryEntity")
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+        
+        try persistentContainer.viewContext.execute(deleteRequest)
+        save()
+    }
+}
+
+// MARK: - Helper Functions
+
+private extension CoreDataStack {
+    func findUserEntity(with username: String) throws -> UserEntity? {
+        let fetchRequest = UserEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "username == %@", username)
+        
+        if let result = try persistentContainer.viewContext.fetch(fetchRequest).first {
+            return result
+        } else {
+            return nil
+        }
+    }
+    
+    func findKickboardEntity(with kickboardCode: String) throws -> KickboardEntity? {
+        let fetchRequest = KickboardEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "kickboardCode == %@", kickboardCode)
+        
+        if let result = try persistentContainer.viewContext.fetch(fetchRequest).first {
+            return result
+        } else {
+            return nil
+        }
+    }
+    
+    func findKickboardTypeEntity(with typeName: String) throws -> KickboardTypeEntity? {
+        let fetchRequest = KickboardTypeEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "typeName == %@", typeName)
+        
+        if let result = try persistentContainer.viewContext.fetch(fetchRequest).first {
+            return result
+        } else {
+            return nil
+        }
+    }
+}
+
+extension CoreDataStack {
+    func isKickboardInfoSaved() throws -> Bool {
+        let fetchRequest = KickboardEntity.fetchRequest()
+        
+        if let result = try persistentContainer.viewContext.fetch(fetchRequest).first {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    func requestKickboards(minLat: Double, maxLat: Double, minLng: Double, maxLng: Double) throws -> [Kickboard] {
+        let request = KickboardEntity.fetchRequest()
+        
+        request.predicate = NSPredicate(
+            format: "latitude >= %f AND latitude <= %f AND longitude >= %f AND longitude <= %f",
+            minLat, maxLat, minLng, maxLng
+        )
+        
+        let results = try persistentContainer.viewContext.fetch(request)
+        let kickboards = results.map {
+            Kickboard(
+                longitude: $0.longitude,
+                latitude: $0.latitude,
+                kickboardCode: $0.kickboardCode ?? "",
+                isRented: $0.isRented,
+                batteryStatus: $0.batteryStatus,
+                type: KickboardType(rawValue: $0.kickboardType?.typeName ?? "basic") ?? .basic
+            )
+        }
+        return kickboards
+    }
+}

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/MainView/MainViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/MainView/MainViewController.swift
@@ -68,9 +68,6 @@ class MainViewController: UIViewController {
     }
     
     private func loadNearbyKickboards(at location: CLLocation) {
-        let context = CoreDataManager.shared.context
-        let request: NSFetchRequest<KickboardEntity> = KickboardEntity.fetchRequest()
-        
         let spanRange = min(mapView.region.span.latitudeDelta / 2, maxRange/2)
 
         let minLat = location.coordinate.latitude - spanRange
@@ -78,25 +75,13 @@ class MainViewController: UIViewController {
         let minLng = location.coordinate.longitude - spanRange
         let maxLng = location.coordinate.longitude + spanRange
         
-        let predicate = NSPredicate(
-            format: "latitude >= %f AND latitude <= %f AND longitude >= %f AND longitude <= %f",
-            minLat, maxLat, minLng, maxLng
-        )
-        
-        request.predicate = predicate
-        
         do {
-            let datas = try context.fetch(request)
-            kickboards = datas.map {
-                Kickboard(
-                    longitude: $0.longitude,
-                    latitude: $0.latitude,
-                    kickboardCode: $0.kickboardCode ?? "",
-                    isRented: $0.isRented,
-                    batteryStatus: $0.batteryStatus
-                )
-            }
-            
+            kickboards = try CoreDataStack.shared.requestKickboards(
+                minLat: minLat,
+                maxLat: maxLat,
+                minLng: minLng,
+                maxLng: maxLng
+            )
             updateAnnotations()
         } catch {
             print("Failed to fetch kickboards: \(error)")

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/HistoryEntity+CoreDataClass.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/HistoryEntity+CoreDataClass.swift
@@ -11,5 +11,11 @@ import CoreData
 
 @objc(HistoryEntity)
 public class HistoryEntity: NSManagedObject {
-
+    enum Key {
+        static let cost = "cost"
+        static let rentDate = "rentDate"
+        static let totalRentTime = "totalRentTime"
+        static let kickboard = "kickboard"
+        static let user = "user"
+    }
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/HistoryEntity+CoreDataProperties.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/HistoryEntity+CoreDataProperties.swift
@@ -22,6 +22,13 @@ extension HistoryEntity {
     @NSManaged public var kickboard: KickboardEntity?
     @NSManaged public var user: UserEntity?
 
+    enum Key {
+        static let cost = "cost"
+        static let rentDate = "rentDate"
+        static let totalRentTime = "totalRentTime"
+        static let kickboard = "kickboard"
+        static let user = "user"
+    }
 }
 
 extension HistoryEntity : Identifiable {

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/HistoryEntity+CoreDataProperties.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/HistoryEntity+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  HistoryEntity+CoreDataProperties.swift
 //  nbc-kickboard
 //
-//  Created by 권승용 on 12/16/24.
+//  Created by 권승용 on 12/18/24.
 //
 //
 
@@ -22,13 +22,6 @@ extension HistoryEntity {
     @NSManaged public var kickboard: KickboardEntity?
     @NSManaged public var user: UserEntity?
 
-    enum Key {
-        static let cost = "cost"
-        static let rentDate = "rentDate"
-        static let totalRentTime = "totalRentTime"
-        static let kickboard = "kickboard"
-        static let user = "user"
-    }
 }
 
 extension HistoryEntity : Identifiable {

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/KickboardEntity+CoreDataClass.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/KickboardEntity+CoreDataClass.swift
@@ -11,5 +11,13 @@ import CoreData
 
 @objc(KickboardEntity)
 public class KickboardEntity: NSManagedObject {
-
+    enum Key {
+        static let batteryStatus = "batteryStatus"
+        static let isRented = "isRented"
+        static let kickboardCode = "kickboardCode"
+        static let latitude = "latitude"
+        static let longitude = "longitude"
+        static let histories = "histories"
+        static let kickboardType = "kickboardType"
+    }
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/KickboardEntity+CoreDataProperties.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/KickboardEntity+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  KickboardEntity+CoreDataProperties.swift
 //  nbc-kickboard
 //
-//  Created by 권승용 on 12/16/24.
+//  Created by 권승용 on 12/18/24.
 //
 //
 
@@ -23,16 +23,7 @@ extension KickboardEntity {
     @NSManaged public var longitude: Double
     @NSManaged public var histories: NSSet?
     @NSManaged public var kickboardType: KickboardTypeEntity?
-    
-    enum Key {
-        static let batteryStatus = "batteryStatus"
-        static let isRented = "isRented"
-        static let kickboardCode = "kickboardCode"
-        static let latitude = "latitude"
-        static let longitude = "longitude"
-        static let histories = "histories"
-        static let kickboardType = "kickboardType"
-    }
+
 }
 
 // MARK: Generated accessors for histories

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/KickboardEntity+CoreDataProperties.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/KickboardEntity+CoreDataProperties.swift
@@ -23,7 +23,16 @@ extension KickboardEntity {
     @NSManaged public var longitude: Double
     @NSManaged public var histories: NSSet?
     @NSManaged public var kickboardType: KickboardTypeEntity?
-
+    
+    enum Key {
+        static let batteryStatus = "batteryStatus"
+        static let isRented = "isRented"
+        static let kickboardCode = "kickboardCode"
+        static let latitude = "latitude"
+        static let longitude = "longitude"
+        static let histories = "histories"
+        static let kickboardType = "kickboardType"
+    }
 }
 
 // MARK: Generated accessors for histories

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/KickboardTypeEntity+CoreDataClass.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/KickboardTypeEntity+CoreDataClass.swift
@@ -11,5 +11,8 @@ import CoreData
 
 @objc(KickboardTypeEntity)
 public class KickboardTypeEntity: NSManagedObject {
-
+    enum Key {
+        static let typeName = "typeName"
+        static let kickboards = "kickboards"
+    }
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/KickboardTypeEntity+CoreDataProperties.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/KickboardTypeEntity+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  KickboardTypeEntity+CoreDataProperties.swift
 //  nbc-kickboard
 //
-//  Created by 권승용 on 12/16/24.
+//  Created by 권승용 on 12/18/24.
 //
 //
 
@@ -19,10 +19,6 @@ extension KickboardTypeEntity {
     @NSManaged public var typeName: String?
     @NSManaged public var kickboards: NSSet?
 
-    enum Key {
-        static let typeName = "typeName"
-        static let kickboards = "kickboards"
-    }
 }
 
 // MARK: Generated accessors for kickboards

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/KickboardTypeEntity+CoreDataProperties.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/KickboardTypeEntity+CoreDataProperties.swift
@@ -19,6 +19,10 @@ extension KickboardTypeEntity {
     @NSManaged public var typeName: String?
     @NSManaged public var kickboards: NSSet?
 
+    enum Key {
+        static let typeName = "typeName"
+        static let kickboards = "kickboards"
+    }
 }
 
 // MARK: Generated accessors for kickboards

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/UserEntity+CoreDataClass.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/UserEntity+CoreDataClass.swift
@@ -11,5 +11,10 @@ import CoreData
 
 @objc(UserEntity)
 public class UserEntity: NSManagedObject {
-
+    enum Key {
+        static let isAdmin = "isAdmin"
+        static let password = "password"
+        static let username = "username"
+        static let histories = "histories"
+    }
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/UserEntity+CoreDataProperties.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/UserEntity+CoreDataProperties.swift
@@ -21,6 +21,12 @@ extension UserEntity {
     @NSManaged public var username: String?
     @NSManaged public var histories: NSSet?
 
+    enum Key {
+        static let isAdmin = "isAdmin"
+        static let password = "password"
+        static let username = "username"
+        static let histories = "histories"
+    }
 }
 
 // MARK: Generated accessors for histories

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/UserEntity+CoreDataProperties.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/CoreDatas/UserEntity+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  UserEntity+CoreDataProperties.swift
 //  nbc-kickboard
 //
-//  Created by 권승용 on 12/16/24.
+//  Created by 권승용 on 12/18/24.
 //
 //
 
@@ -21,12 +21,6 @@ extension UserEntity {
     @NSManaged public var username: String?
     @NSManaged public var histories: NSSet?
 
-    enum Key {
-        static let isAdmin = "isAdmin"
-        static let password = "password"
-        static let username = "username"
-        static let histories = "histories"
-    }
 }
 
 // MARK: Generated accessors for histories

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/History.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/History.swift
@@ -12,4 +12,5 @@ struct History {
     let rentDate: Date
     let totalRentTime: Int16
     let kickboard: Kickboard
+    let user: User
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/History.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/History.swift
@@ -8,5 +8,8 @@
 import Foundation
 
 struct History {
-    
+    let cost: Int16
+    let rentDate: Date
+    let totalRentTime: Int16
+    let kickboard: Kickboard
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/Kickboard.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/Kickboard.swift
@@ -13,6 +13,7 @@ struct Kickboard {
     let kickboardCode: String
     let isRented: Bool
     let batteryStatus: Int16
+    let type: KickboardType
 }
 
 struct Location: Codable {

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/KickboardType.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/KickboardType.swift
@@ -1,0 +1,11 @@
+//
+//  KickboardType.swift
+//  nbc-kickboard
+//
+//  Created by 권승용 on 12/18/24.
+//
+
+enum KickboardType: String, CaseIterable {
+    case basic
+    case power
+}

--- a/nbc-kickboard/nbc-kickboard/Sources/Models/User.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Models/User.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 struct User {
-    
+    let username: String
+    var isAdmin: Bool
 }

--- a/nbc-kickboard/nbc-kickboardTests/CoreDataStackTests.swift
+++ b/nbc-kickboard/nbc-kickboardTests/CoreDataStackTests.swift
@@ -1,0 +1,284 @@
+//
+//  CoreDataStackTests.swift
+//  nbc-kickboard
+//
+//  Created by 권승용 on 12/18/24.
+//
+
+import Testing
+import CoreData
+@testable import nbc_kickboard
+
+@MainActor
+final class CoreDataStackTests {
+    var sut: CoreDataStack
+    
+    init() {
+        sut = CoreDataStack.shared
+        CoreDataStack.shared.createKickboardType(name: "basic")
+        CoreDataStack.shared.createKickboardType(name: "power")
+    }
+    
+    deinit {
+        do {
+            try sut.deleteAll()
+        } catch {
+            print("error")
+        }
+    }
+    
+    // MARK: - User Tests
+    
+    @MainActor
+    @Test
+    func createAndReadUser() throws {
+        // Given
+        let testUsername = "testUser"
+        let testPassword = "password123"
+        let testIsAdmin = false
+        
+        // When
+        sut.createUser(name: testUsername, password: testPassword, isAdmin: testIsAdmin)
+        let user = try sut.readUser(name: testUsername)
+        
+        // Then
+        #expect(user.username == testUsername)
+        #expect(user.isAdmin == false)
+    }
+    
+    @MainActor
+    @Test
+    func updateUser() throws {
+        // Given
+        let testUsername = "testUser"
+        let testPassword = "password123"
+        let testIsAdmin = false
+        sut.createUser(name: testUsername, password: testPassword, isAdmin: testIsAdmin)
+        
+        // When
+        try sut.updateUser(name: testUsername, password: "newPassword", isAdmin: true)
+        let updatedUser = try sut.readUser(name: testUsername)
+        
+        // Then
+        #expect(updatedUser.isAdmin == true)
+    }
+    
+    @MainActor
+    @Test
+    func deleteUser() throws {
+        // Given
+        let testUsername = "testUser"
+        let testPassword = "password123"
+        let testIsAdmin = false
+        sut.createUser(name: testUsername, password: testPassword, isAdmin: testIsAdmin)
+        
+        // When
+        try sut.deleteUser(name: testUsername)
+        
+        // Then
+        #expect(throws: AppError.CoreDataStackError.noMatchingItem) {
+            try sut.readUser(name: testUsername)
+        }
+    }
+    
+    // MARK: - Kickboard Tests
+    
+    @MainActor
+    @Test
+    func createAndReadKickboard() throws {
+        // Given
+        let testCode = "KB001"
+        let testBattery: Int16 = 100
+        let testIsRented = false
+        let testLatitude = 37.5665
+        let testLongitude = 126.9780
+        let testType: KickboardType = .basic
+        
+        // When
+        try sut.createKickboard(
+            kickboardCode: testCode,
+            batteryStatus: testBattery,
+            isRented: testIsRented,
+            latitude: testLatitude,
+            longitude: testLongitude,
+            type: testType
+        )
+        let kickboard = try sut.readKickboard(kickboardCode: testCode)
+        
+        // Then
+        #expect(kickboard.kickboardCode == testCode)
+        #expect(kickboard.batteryStatus == testBattery)
+        #expect(kickboard.isRented == testIsRented)
+        #expect(kickboard.latitude == testLatitude)
+        #expect(kickboard.longitude == testLongitude)
+        #expect(kickboard.type == testType)
+    }
+    
+    @MainActor
+    @Test
+    func updateKickboard() throws {
+        // Given
+        let testCode = "KB001"
+        try sut.createKickboard(
+            kickboardCode: testCode,
+            batteryStatus: 100,
+            isRented: false,
+            latitude: 37.5665,
+            longitude: 126.9780,
+            type: .basic
+        )
+        
+        // When
+        try sut.updateKickboard(
+            kickboardCode: testCode,
+            batteryStatus: 90,
+            isRented: true,
+            latitude: 37.5666,
+            longitude: 126.9781,
+            type: .power
+        )
+        let updatedKickboard = try sut.readKickboard(kickboardCode: testCode)
+        
+        // Then
+        #expect(updatedKickboard.batteryStatus == 90)
+        #expect(updatedKickboard.isRented == true)
+        #expect(updatedKickboard.latitude == 37.5666)
+        #expect(updatedKickboard.longitude == 126.9781)
+        #expect(updatedKickboard.type == .power)
+    }
+    
+    @MainActor
+    @Test
+    func deleteKickboard() throws {
+        // Given
+        let testCode = "KB001"
+        try sut.createKickboard(
+            kickboardCode: testCode,
+            batteryStatus: 100,
+            isRented: false,
+            latitude: 37.5665,
+            longitude: 126.9780,
+            type: .basic
+        )
+        
+        // When
+        try sut.deleteKickboard(kickboardCode: testCode)
+        
+        // Then
+        #expect(throws: AppError.CoreDataStackError.noMatchingItem) {
+            try sut.readKickboard(kickboardCode: testCode)
+        }
+    }
+    
+    @MainActor
+    @Test
+    func createAndReadHistory() throws {
+        // Given
+        let testUsername = "testUser"
+        let testPassword = "password123"
+        let testKickboardCode = "KB001"
+        
+        // Create prerequisite data
+        sut.createUser(name: testUsername, password: testPassword, isAdmin: false)
+        try sut.createKickboard(
+            kickboardCode: testKickboardCode,
+            batteryStatus: 100,
+            isRented: false,
+            latitude: 37.5665,
+            longitude: 126.9780,
+            type: .basic
+        )
+        
+        let testCost: Int16 = 5000
+        let testRentDate = Date()
+        let testTotalRentTime: Int16 = 30
+        
+        // When
+        try sut.createHistory(
+            username: testUsername,
+            kickboardCode: testKickboardCode,
+            cost: testCost,
+            rentDate: testRentDate,
+            totalRentTime: testTotalRentTime
+        )
+        let histories = try sut.readAllHistory(of: testUsername)
+        
+        // Then
+        #expect(histories.count == 1)
+        #expect(histories[0].cost == testCost)
+        #expect(histories[0].totalRentTime == testTotalRentTime)
+        #expect(histories[0].user.username == testUsername)
+        #expect(histories[0].kickboard.kickboardCode == testKickboardCode)
+    }
+    
+    @MainActor
+    @Test
+    func deleteAllHistory() throws {
+        // Given
+        let testUsername = "testUser"
+        let testPassword = "password123"
+        let testKickboardCode = "KB001"
+        
+        sut.createUser(name: testUsername, password: testPassword, isAdmin: false)
+        try sut.createKickboard(
+            kickboardCode: testKickboardCode,
+            batteryStatus: 100,
+            isRented: false,
+            latitude: 37.5665,
+            longitude: 126.9780,
+            type: .basic
+        )
+        
+        try sut.createHistory(
+            username: testUsername,
+            kickboardCode: testKickboardCode,
+            cost: 5000,
+            rentDate: Date(),
+            totalRentTime: 30
+        )
+        
+        // When
+        try sut.deleteAllHistory()
+        let histories = try sut.readAllHistory(of: testUsername)
+        
+        // Then
+        #expect(histories.isEmpty)
+    }
+    
+    // MARK: - KickboardType Tests
+    
+    @MainActor
+    @Test
+    func createKickboardType() throws {
+        // Given
+        let testTypeName = "test_type"
+        
+        // When
+        sut.createKickboardType(name: testTypeName)
+        
+        // Then
+        let fetchRequest = NSFetchRequest<NSManagedObject>(entityName: "KickboardTypeEntity")
+        fetchRequest.predicate = NSPredicate(format: "typeName == %@", testTypeName)
+        let result = try sut.persistentContainer.viewContext.fetch(fetchRequest)
+        
+        #expect(!result.isEmpty)
+        #expect(result[0].value(forKey: KickboardTypeEntity.Key.typeName) as? String == testTypeName)
+    }
+    
+    @MainActor
+    @Test
+    func deleteAllKickboardType() throws {
+        // Given
+        let testTypeName = "test_type"
+        sut.createKickboardType(name: testTypeName)
+        
+        // When
+        try sut.deleteAllKickboardType()
+        
+        // Then
+        let fetchRequest = NSFetchRequest<NSManagedObject>(entityName: "KickboardTypeEntity")
+        let result = try sut.persistentContainer.viewContext.fetch(fetchRequest)
+        
+        #expect(result.isEmpty)
+    }
+}


### PR DESCRIPTION
## 📓 Overview
- User, Kickboard, KickboardType, History 등 각 엔티티에 대한 CRUD를 담당하는 코어데이터 스택을 구현하였습니다.
- User, Kickboard, KickboardType, History 모델을 구현하였습니다.
- AppDelegate에 킥보드 타입 주입 코드를 작성하였습니다.
- 코어데이터 스택 CRUD는 엔티티에 대한 접근이 필요없이 일반 데이터로 가능합니다.

## 🤔 고민 내용
### 너무 큰 코어데이터 스택
- 중복코드를 제거하고 경량화시킬 수 있는지 고민하면 좋을 것 같습니다
