### PR TITLE
모달뷰 컨트롤러 구현 완료 및 로그인, 가입 경고창 UI 완성 외

### DIFF
--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UILabel+extension.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Extensions/UILabel+extension.swift
@@ -21,7 +21,7 @@ extension UILabel {
         }
     }
     
-    // input 위에 input 설명용 라벨
+    /// input 위에 input 설명용 라벨
     func applyInputLabelStyle(text: String) {
         self.text = text
         self.backgroundColor = .clear
@@ -29,5 +29,68 @@ extension UILabel {
         self.font = Fonts.cap
         self.textColor = Colors.gray1
         self.numberOfLines = 0
+    }
+    
+    /// 알림창 제목 스타일
+    /// - Parameter text: 제목 텍스트
+    func applyAlertTitleLabel(text: String) {
+        self.text = text
+        self.backgroundColor = .clear
+        self.textAlignment = .center
+        self.font = Fonts.subtitleBold
+        self.textColor = Colors.main
+        self.numberOfLines = 1
+    }
+    
+    /// 알림창 메시지 스타일
+    /// - Parameter text: 메시지 텍스트
+    func applyAlertMessageLabel(text: String) {
+        self.text = text
+        self.backgroundColor = .clear
+        self.textAlignment = .left
+        self.font = Fonts.body
+        self.textColor = Colors.black
+        self.numberOfLines = 0
+    }
+}
+
+
+// MARK: - UILabel Utilities
+
+extension UILabel {
+    /// UILabel 에 줄간격을 쉽게 적용시켜 사용하기 위한 메소드
+    /// 기본값을 설정하였으므로 아래 둘 중 하나를 선택하여 사용.
+    /// - Parameters:
+    ///   - lineSpacing: 각 줄 사이의 간격을 의미합니다.
+    ///   - paragraphSpacing: 문단 간격을 설정합니다.
+    func setLineSpacing(lineSpacing: CGFloat = 0.0, paragraphSpacing:CGFloat = 0.0) {
+        guard let labelText = self.text else { return }
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        
+        paragraphStyle.lineSpacing = lineSpacing
+        paragraphStyle.paragraphSpacing = paragraphSpacing
+
+        let attributedString:NSMutableAttributedString
+        
+        if let labelattributedText = self.attributedText {
+            attributedString = NSMutableAttributedString(attributedString: labelattributedText)
+        } else {
+            attributedString = NSMutableAttributedString(string: labelText)
+        }
+
+        // Line spacing attribute
+        attributedString.addAttribute(NSAttributedString.Key.paragraphStyle, value:paragraphStyle, range:NSMakeRange(0, attributedString.length))
+
+        self.attributedText = attributedString
+        
+        /*
+         위 메소드는 다음과 같은 형식으로 사용합니다.
+         let label = UILabel()
+         
+         label.setLineSpacing(lineSpacing: 10.0)
+         label.setLineSpacing(paragraphSpacing: 10.0)
+         label.setLineSpacing(lineSpacing: 10.0, paragraphSpacing: 10.0)
+         */
     }
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/ModalManager.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Core/Managers/ModalManager.swift
@@ -17,16 +17,16 @@ struct ModalManager {
     ///   - preventGesture : 모달 제스쳐 비활성화 여부
     /// - Returns: UIView가 삽입된 전역 모달뷰컨트롤러를 반환.
     static func createGlobalModal(
-        content: UIView,
+        content: ModalCloseable,
         preventGesture: Bool = true,
-        initAction: (() -> Void)?,
-        dismissAction: (() -> Void)?
+        initAction: (() -> Void) = {},
+        dismissAction: (() -> Void) = {}
     ) -> GlobalModalViewController? {
         guard let topVC = AppHelpers.getTopViewController() else {
             return nil
         }
         
-        let modalVC = GlobalModalViewController(content)
+        let modalVC = GlobalModalViewController(modalContentsView: content)
         modalVC.modalPresentationStyle = .overFullScreen
         modalVC.modalTransitionStyle = .crossDissolve
         
@@ -36,7 +36,7 @@ struct ModalManager {
             modalVC.isModalInPresentation = preventGesture
         }
         
-        topVC.present(modalVC, animated: true, completion: initAction)
+        topVC.present(modalVC, animated: true)
         
         return modalVC
     }

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/AuthViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/AuthViewController.swift
@@ -88,8 +88,9 @@ extension AuthViewController {
             
         case .failure(let error):
             let errorMessage: String = error.messages.reduce("") { "\($0)\n- \($1)" }
-            
-            AppHelpers.showBasicAlert(title: "로그인 실패", message: errorMessage, action: { print("Alert 종료")})
+            print(errorMessage)
+            let alertView = AlertView(title: "로그인 실패", message: errorMessage)
+            let _ = ModalManager.createGlobalModal(content: alertView)
         }
     }
     

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Components/AlertView.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Components/AlertView.swift
@@ -9,13 +9,89 @@ import UIKit
 import SnapKit
 
 
-//class AlertView: UIView {
-//    
-//    let titleLabel = UILabel()
-//    let messageLabel = UILabel()
-//    let confirmButton = UIButton()
-//    
-//    init() {
-//        
-//    }
-//}
+/// 단순 알림창 팝업을 위한 뷰
+class AlertView: UIView, ModalLifecycleNotifiable, ModalCloseable {
+    
+    let titleLabel = UILabel()
+    let messageLabel = UILabel()
+    let confirmButton = UIButton()
+    
+    let title: String
+    let message: String
+    let completion: () -> Void
+    
+    weak var delegate: ModalCloseDelegate?
+    
+    /// 뷰에 들어갈 텍스트와 버튼 클릭시 작동하는 클로저를 인자로 받습니다.
+    /// 버튼 클릭시 기본적으로 모달뷰 자체를 dismiss 하도록 되어 있습니다.
+    /// - Parameters:
+    ///   - title: 알림창의 상단 제목
+    ///   - message: 알림창의 세부 메시지
+    ///   - completion: 알림창의 버튼 클릭 후 작동하는 클로져
+    init(title: String, message: String, completion: @escaping () -> Void = {}) {
+        self.title = title
+        self.message = message
+        self.completion = completion
+        super.init(frame: .zero)
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setupUI() {
+        [
+            titleLabel,
+            messageLabel,
+            confirmButton
+        ].forEach { addSubview($0) }
+        
+        titleLabel.applyAlertTitleLabel(text: title)
+        messageLabel.applyAlertMessageLabel(text: message)
+        messageLabel.setLineSpacing(lineSpacing: 8, paragraphSpacing: 16)
+        confirmButton.applyFullSizeButtonStyle(title: "확인", bgColor: Colors.main, isRadius: true)
+        confirmButton.applyButtonAction(action: closeModal)
+        
+        
+        self.backgroundColor = Colors.white
+        self.layer.cornerRadius = 16
+        
+        self.snp.makeConstraints {
+            $0.height.greaterThanOrEqualTo(100)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(Layouts.paddingBig)
+            $0.leading.trailing.equalToSuperview().inset(Layouts.paddingSmall)
+        }
+        
+        messageLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview().inset(Layouts.paddingSmall)
+        }
+        
+        confirmButton.snp.makeConstraints {
+            $0.top.equalTo(messageLabel.snp.bottom).offset(48)
+            $0.bottom.equalToSuperview().inset(Layouts.padding)
+            $0.leading.trailing.equalToSuperview().inset(Layouts.paddingSmall)
+        }
+    }
+}
+
+
+extension AlertView {
+    func onModalWillAppear() {
+        print("모달 나타난다.")
+    }
+    
+    func onModalWillDisappear() {
+        print("모달 사라진다.")
+    }
+    
+    func closeModal() {
+        delegate?.closeModal()
+        completion()
+    }
+}

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Modal/GlobalModalViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/Modal/GlobalModalViewController.swift
@@ -14,7 +14,16 @@ protocol ModalLifecycleNotifiable: AnyObject {
     func onModalWillDisappear()
 }
 
-final class GlobalModalViewController: UIViewController {
+protocol ModalCloseDelegate: AnyObject {
+    func closeModal()
+}
+
+protocol ModalCloseable: AnyObject {
+    var delegate: ModalCloseDelegate? { get set }
+    func closeModal()
+}
+
+final class GlobalModalViewController: UIViewController, ModalCloseDelegate {
     // MARK: - Properties
 
     private let modalContentsView: UIView
@@ -22,9 +31,11 @@ final class GlobalModalViewController: UIViewController {
     
     // MARK: - init & Life cyclesas
 
-    init(_ modalContentsView: UIView ) {
-        self.modalContentsView = modalContentsView
+    init(modalContentsView: ModalCloseable ) {
+        self.modalContentsView = modalContentsView as! UIView
         super.init(nibName: nil, bundle: nil)
+        
+        modalContentsView.delegate = self
     }
 
     required init?(coder: NSCoder) {
@@ -81,5 +92,7 @@ extension GlobalModalViewController {
 // MARK: - Action Management & Mapping
 
 extension GlobalModalViewController {
-    
+    func closeModal() {
+        self.dismiss(animated: true, completion: nil)
+    }
 }

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/SignupViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/AuthView/SignupViewController.swift
@@ -50,50 +50,34 @@ extension SignupViewController {
 }
 
 
-// MARK: - Navigation Controll
-
-extension SignupViewController {
-    
-}
-
-
 // MARK: - Action Management & Mapping
 
 extension SignupViewController {
     
+    /// 회원가입을 요청하는 메소드.
+    /// - Parameters:
+    ///   - username: 사용자가 입력한 사용자 아이디
+    ///   - password: 사용자가 입력한 사용자 암호
     func requestSignup(username: String, password: String) {
         let result = signupUseCase.execute(( username: username, password: password, isAdmin: isAdmin ))
         switch result {
         case .success:
-            print("sucess")
-            let alert = UIAlertController(
-                title: "가입 완료",
-                message: "회원 가입이 완료되었습니다. 로그인 해주세요.",
-                preferredStyle: .alert
-            )
-            
-            let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
+            let alertView = AlertView(title: "회원 가입 성공", message: "로그인 화면으로 돌아갑니다.") {
                 self.navigationController?.popViewController(animated: true)
             }
-            alert.addAction(confirmAction)
-            present(alert, animated: true)
             
+            let _ = ModalManager.createGlobalModal(content: alertView)
         case .failure(let error):
-            print(error.messages)
             let errorMessage: String = error.messages.reduce("") { "\($0)\n- \($1)" }
-            let alert = UIAlertController(
-                title: "회원 가입 실패",
-                message: errorMessage,
-                preferredStyle: .alert
-            )
+            print(errorMessage)
+            let alertView = AlertView(title: "회원 가입 실패", message: errorMessage)
             
-            let cancelAction = UIAlertAction(title: "확인", style: .default)
-            alert.addAction(cancelAction)
-            
-            present(alert, animated: true)
+            let _ = ModalManager.createGlobalModal(content: alertView)
         }
     }
     
+    /// 가입 단계의 관리자 여부를 선택하는 토글 버튼의 상태 데이터와 뷰를 연결.
+    /// 이런 식으로 데이터와 뷰 화면 반영을 구성하는 게 맞는건지 잘 모르겠습니다.
     func toggleAgreementStatus() {
         isAdmin.toggle()
         signupView.agreementButton.isSelected = isAdmin


### PR DESCRIPTION
## 📓 Overview
- 모달뷰의 하위뷰에 대해 프로토콜을 통해 필수 형태 제약을 검.
- 피그마 디자인을 반영한 알림창 구현
- 알림창에 후행클로져를 삽입해 필요한 기능을 수행할 수 있도록 함.
- 기존 기본 알림창을 모두 디자인된 알림창으로 변경.
- UILabel extension 에 줄간격을 조절가능한 메소드 추가.

## 🤔 고민 내용
- UIKit 은 참 구린 거 같습니다...

## 📸 스샷
![Simulator Screenshot - iPhone 16 Pro - 2024-12-19 at 17 16 55](https://github.com/user-attachments/assets/b07643d9-732f-4ecc-87fd-3e1db21dee1d)
enshot

