### PR TITLE
킥보드 타입에 따른 마커 이미지 적용 로직 추가

### DIFF
--- a/nbc-kickboard/nbc-kickboard/Sources/Features/MainView/MainViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/MainView/MainViewController.swift
@@ -4,6 +4,20 @@ import CoreLocation
 import Combine
 import CoreData
 
+class CustomAnnotation: NSObject, MKAnnotation {
+    var coordinate: CLLocationCoordinate2D
+    var title: String?
+    var subtitle: String?
+    var kickboardType: KickboardType?
+    
+    init(coordinate: CLLocationCoordinate2D, title: String? = nil, subtitle: String? = nil, kickboardType: KickboardType? = nil) {
+        self.coordinate = coordinate
+        self.title = title
+        self.subtitle = subtitle
+        self.kickboardType = kickboardType
+    }
+}
+
 class MainViewController: UIViewController {
     private let mainView = MainView()
     private let locationManager = CLLocationManager()
@@ -22,6 +36,7 @@ class MainViewController: UIViewController {
         setupActions()
         setupLocationManager()
         setupBindings()
+        mainView.mapView.delegate = self
     }
 
     private func setupActions() {
@@ -132,15 +147,28 @@ class MainViewController: UIViewController {
         mainView.mapView.removeAnnotations(existingAnnotations)
         
         // 지도 위치 변경 시, 새로 보이는 영역에 있는 킥보드들 지도에 표시
-        let annotations = kickboards.map { kickboard -> MKPointAnnotation in
-            let annotation = MKPointAnnotation()
-            annotation.coordinate = CLLocationCoordinate2D(
-                latitude: kickboard.latitude,
-                longitude: kickboard.longitude
+//        let annotations = kickboards.map { kickboard -> MKPointAnnotation in
+//            let annotation = MKPointAnnotation()
+//            annotation.coordinate = CLLocationCoordinate2D(
+//                latitude: kickboard.latitude,
+//                longitude: kickboard.longitude
+//            )
+//            
+//            annotation.title = "배터리: \(kickboard.batteryStatus)%"
+//            annotation.subtitle = kickboard.kickboardCode
+//            return annotation
+//        }
+        
+        let annotations = kickboards.map { kickboard -> CustomAnnotation in
+            let annotation = CustomAnnotation(
+                coordinate: CLLocationCoordinate2D(
+                    latitude: kickboard.latitude,
+                    longitude: kickboard.longitude)
             )
             
             annotation.title = "배터리: \(kickboard.batteryStatus)%"
             annotation.subtitle = kickboard.kickboardCode
+            annotation.kickboardType = kickboard.type
             return annotation
         }
         
@@ -197,7 +225,7 @@ extension MainViewController: MKMapViewDelegate {
         if annotationView == nil {
             annotationView = MKAnnotationView(annotation: annotation, reuseIdentifier: identifier)
             annotationView?.canShowCallout = true
-            annotationView?.image = UIImage(named: "map_pin2")
+//            annotationView?.image = UIImage(named: "map_pin2")
             
             // 오른쪽 버튼 추가
             let rightButton = UIButton(type: .detailDisclosure)
@@ -206,6 +234,17 @@ extension MainViewController: MKMapViewDelegate {
         }
         
         annotationView?.annotation = annotation
+        
+        if let customAnnotation = annotation as? CustomAnnotation {
+            switch customAnnotation.kickboardType {
+            case .basic:
+                annotationView?.image = UIImage(named: "map_pin1")
+            case .power:
+                annotationView?.image = UIImage(named: "map_pin2")
+            case .none:
+                break
+            }
+        }
         
         return annotationView
     }

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/MyPageView/MyPage/MyPageViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/MyPageView/MyPage/MyPageViewController.swift
@@ -9,12 +9,18 @@ import UIKit
 import SnapKit
 import Combine
 
+protocol MyPageViewControllerDelegate: AnyObject {
+    func requestLogout()
+}
+
 
 final class MyPageViewController: UIViewController {
     private let myPageView = MyPageView()
     private let kickboardManager = KickboardManager.shared
     private var cancellables = Set<AnyCancellable>()
     private var currentUser: User?
+    
+    weak var delegate: MyPageViewControllerDelegate?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -74,11 +80,7 @@ extension MyPageViewController: MyPageViewDelegate {
         print("change password Tapped")
     }
     
-    func logoutButtonDidTapped() {
-        UserDefaults.standard.removeObject(forKey: "username")
-        UserDefaults.standard.removeObject(forKey: "isAdmin")
-        navigationController?.popViewController(animated: false)
-    }
+    func logoutButtonDidTapped() { delegate?.requestLogout() }
 }
 
 // MARK: - Business Logic

--- a/nbc-kickboard/nbc-kickboard/Sources/Features/TabView/TabViewController.swift
+++ b/nbc-kickboard/nbc-kickboard/Sources/Features/TabView/TabViewController.swift
@@ -71,7 +71,9 @@ final class CustomTabBarController: UIViewController {
                     addViewController.delegate = self
                     viewController = addViewController
                 case .my:
-                    viewController = UINavigationController(rootViewController: MyPageViewController())
+                    let myPageViewController = MyPageViewController()
+                    myPageViewController.delegate = self
+                    viewController = UINavigationController(rootViewController: myPageViewController)
                 }
                 
                 addChild(viewController)
@@ -108,6 +110,14 @@ extension CustomTabBarController: AddViewControllerDelegate {
         customTabBar.selectedIndex = 0
         
         delegate?.createKickboardLocation(createdKickboardLoaction)
+    }
+}
+
+extension CustomTabBarController: MyPageViewControllerDelegate {
+    func requestLogout() {
+        UserDefaults.standard.removeObject(forKey: "username")
+        UserDefaults.standard.removeObject(forKey: "isAdmin")
+        navigationController?.popViewController(animated: false)
     }
 }
 


### PR DESCRIPTION
## 📓 Overview
- 킥보드 타입별 마커이미지 적용로직 추가
- 기존 title과 subtitle에 내용이 이미 등록된 내용이 있어 annotation 객체에서 식별할 수 있는 별도 프로퍼티가 필요하다 판단
- 커스텀 annotation 객체를 만들어 type 프로퍼티를 추가시키고 이를 통해 마커 이미지 등록

- 로그아웃 리팩토링
- myPageVC에서 HistoryVC로 화전을 전환하기 위한 네비게이션 컨트롤러 필요
- 이를 위해 Mypage에 델리게이트를 구축하여 TapBar로 전달 TabBar에서 pop 작성 수행